### PR TITLE
Add libjpeg-turbo build and remove libpng/zlib dependencies.

### DIFF
--- a/Visual Studio 2022/ps-image/ps-image.vcxproj
+++ b/Visual Studio 2022/ps-image/ps-image.vcxproj
@@ -54,37 +54,6 @@
     <ClCompile Include="..\..\sdk\imgui\imgui_tables.cpp" />
     <ClCompile Include="..\..\sdk\imgui\imgui_widgets.cpp" />
     <ClCompile Include="..\..\sdk\imgui\misc\cpp\imgui_stdlib.cpp" />
-    <ClCompile Include="..\..\sdk\libpng\png.c" />
-    <ClCompile Include="..\..\sdk\libpng\pngerror.c" />
-    <ClCompile Include="..\..\sdk\libpng\pngget.c" />
-    <ClCompile Include="..\..\sdk\libpng\pngmem.c" />
-    <ClCompile Include="..\..\sdk\libpng\pngpread.c" />
-    <ClCompile Include="..\..\sdk\libpng\pngread.c" />
-    <ClCompile Include="..\..\sdk\libpng\pngrio.c" />
-    <ClCompile Include="..\..\sdk\libpng\pngrtran.c" />
-    <ClCompile Include="..\..\sdk\libpng\pngrutil.c" />
-    <ClCompile Include="..\..\sdk\libpng\pngset.c" />
-    <ClCompile Include="..\..\sdk\libpng\pngtest.c" />
-    <ClCompile Include="..\..\sdk\libpng\pngtrans.c" />
-    <ClCompile Include="..\..\sdk\libpng\pngwio.c" />
-    <ClCompile Include="..\..\sdk\libpng\pngwrite.c" />
-    <ClCompile Include="..\..\sdk\libpng\pngwtran.c" />
-    <ClCompile Include="..\..\sdk\libpng\pngwutil.c" />
-    <ClCompile Include="..\..\sdk\zlib\adler32.c" />
-    <ClCompile Include="..\..\sdk\zlib\compress.c" />
-    <ClCompile Include="..\..\sdk\zlib\crc32.c" />
-    <ClCompile Include="..\..\sdk\zlib\deflate.c" />
-    <ClCompile Include="..\..\sdk\zlib\gzclose.c" />
-    <ClCompile Include="..\..\sdk\zlib\gzlib.c" />
-    <ClCompile Include="..\..\sdk\zlib\gzread.c" />
-    <ClCompile Include="..\..\sdk\zlib\gzwrite.c" />
-    <ClCompile Include="..\..\sdk\zlib\infback.c" />
-    <ClCompile Include="..\..\sdk\zlib\inffast.c" />
-    <ClCompile Include="..\..\sdk\zlib\inflate.c" />
-    <ClCompile Include="..\..\sdk\zlib\inftrees.c" />
-    <ClCompile Include="..\..\sdk\zlib\trees.c" />
-    <ClCompile Include="..\..\sdk\zlib\uncompr.c" />
-    <ClCompile Include="..\..\sdk\zlib\zutil.c" />
     <ClCompile Include="..\..\sony-lib\sony_bitstream.cpp" />
     <ClCompile Include="..\..\sony-lib\sony_texture.cpp" />
     <ClCompile Include="Source\app.cpp" />
@@ -125,24 +94,6 @@
     <ClInclude Include="..\..\sdk\imgui\imstb_textedit.h" />
     <ClInclude Include="..\..\sdk\imgui\imstb_truetype.h" />
     <ClInclude Include="..\..\sdk\imgui\misc\cpp\imgui_stdlib.h" />
-    <ClInclude Include="..\..\sdk\libpng\png.h" />
-    <ClInclude Include="..\..\sdk\libpng\pngconf.h" />
-    <ClInclude Include="..\..\sdk\libpng\pngdebug.h" />
-    <ClInclude Include="..\..\sdk\libpng\pnginfo.h" />
-    <ClInclude Include="..\..\sdk\libpng\pnglibconf.h" />
-    <ClInclude Include="..\..\sdk\libpng\pngpriv.h" />
-    <ClInclude Include="..\..\sdk\libpng\pngstruct.h" />
-    <ClInclude Include="..\..\sdk\zlib\crc32.h" />
-    <ClInclude Include="..\..\sdk\zlib\deflate.h" />
-    <ClInclude Include="..\..\sdk\zlib\gzguts.h" />
-    <ClInclude Include="..\..\sdk\zlib\inffast.h" />
-    <ClInclude Include="..\..\sdk\zlib\inffixed.h" />
-    <ClInclude Include="..\..\sdk\zlib\inflate.h" />
-    <ClInclude Include="..\..\sdk\zlib\inftrees.h" />
-    <ClInclude Include="..\..\sdk\zlib\trees.h" />
-    <ClInclude Include="..\..\sdk\zlib\zconf.h" />
-    <ClInclude Include="..\..\sdk\zlib\zlib.h" />
-    <ClInclude Include="..\..\sdk\zlib\zutil.h" />
     <ClInclude Include="..\..\sony-lib\sony_bitstream.h" />
     <ClInclude Include="..\..\sony-lib\sony_bitstream_table.h" />
     <ClInclude Include="..\..\sony-lib\sony_texture.h" />
@@ -160,10 +111,6 @@
     <Xml Include="Windows\manifest.xml" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\..\sdk\libpng\LICENSE" />
-    <None Include="..\..\sdk\libpng\README" />
-    <None Include="..\..\sdk\zlib\LICENSE" />
-    <None Include="..\..\sdk\zlib\README" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
@@ -245,11 +192,11 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;MSTD_DEVICE;MSTD_DX9;LIB_JPEG;LIB_PNG;IMGUI_IMPL_WIN32_DISABLE_GAMEPAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;MSTD_DEVICE;MSTD_DX9;LIB_JPEG;IMGUI_IMPL_WIN32_DISABLE_GAMEPAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
-      <AdditionalIncludeDirectories>$(SolutionDir)Windows;../../mstd-lib;../../mstd-lib/Windows;../../mstd-lib/DX9;../../sony-lib;../../sdk/zlib;../../sdk/libjpeg-turbo/src;../../sdk/libpng;../../sdk/imgui;../../sdk/imgui/backends;../../sdk/imgui/misc/cpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)Windows;../../mstd-lib;../../mstd-lib/Windows;../../mstd-lib/DX9;../../sony-lib;../../sdk/zlib;../../sdk/libjpeg-turbo/build/$(Platform);../../sdk/libjpeg-turbo/src;../../sdk/libpng;../../sdk/imgui;../../sdk/imgui/backends;../../sdk/imgui/misc/cpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
@@ -257,7 +204,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>
       </AdditionalDependencies>
-      <AdditionalLibraryDirectories>../../sdk/libjpeg-turbo/bin/Debug/x86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../sdk/libjpeg-turbo/build/$(Platform)/$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <Manifest>
       <AdditionalManifestFiles>".\\Windows\\manifest.xml" %(AdditionalManifestFiles)</AdditionalManifestFiles>
@@ -272,7 +219,9 @@
       <EnableDpiAwareness>true</EnableDpiAwareness>
     </Manifest>
     <PreBuildEvent>
-      <Command>copy /y ".//icons.png" "$(SolutionDir)Build\$(Configuration)\$(Platform)\icons.png"</Command>
+      <Command>copy /y ".//icons.png" "$(SolutionDir)Build\$(Configuration)\$(Platform)\icons.png"
+cmake "$(SolutionDir)..\..\sdk\libjpeg-turbo" -B "$(SolutionDir)..\..\sdk\libjpeg-turbo\build\$(Platform)" -A $(Platform)
+cmake --build "$(SolutionDir)..\..\sdk\libjpeg-turbo\build\$(Platform)" --config $(Configuration)</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -281,11 +230,11 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;MSTD_DEVICE;MSTD_DX9;LIB_JPEG;LIB_PNG;IMGUI_IMPL_WIN32_DISABLE_GAMEPAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;MSTD_DEVICE;MSTD_DX9;LIB_JPEG;IMGUI_IMPL_WIN32_DISABLE_GAMEPAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
-      <AdditionalIncludeDirectories>$(SolutionDir)Windows;../../mstd-lib;../../mstd-lib/Windows;../../mstd-lib/DX9;../../sony-lib;../../sdk/zlib;../../sdk/libjpeg-turbo/src;../../sdk/libpng;../../sdk/imgui;../../sdk/imgui/backends;../../sdk/imgui/misc/cpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)Windows;../../mstd-lib;../../mstd-lib/Windows;../../mstd-lib/DX9;../../sony-lib;../../sdk/zlib;../../sdk/libjpeg-turbo/build/$(Platform);../../sdk/libjpeg-turbo/src;../../sdk/libpng;../../sdk/imgui;../../sdk/imgui/backends;../../sdk/imgui/misc/cpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
@@ -295,25 +244,27 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>
       </AdditionalDependencies>
-      <AdditionalLibraryDirectories>../../sdk/libjpeg-turbo/bin/Release/x86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../sdk/libjpeg-turbo/build/$(Platform)/$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <Manifest>
       <AdditionalManifestFiles>".\\Windows\\manifest.xml" %(AdditionalManifestFiles)</AdditionalManifestFiles>
       <EnableDpiAwareness>true</EnableDpiAwareness>
     </Manifest>
     <PreBuildEvent>
-      <Command>copy /y ".//icons.png" "$(SolutionDir)Build\$(Configuration)\$(Platform)\icons.png"</Command>
+      <Command>copy /y ".//icons.png" "$(SolutionDir)Build\$(Configuration)\$(Platform)\icons.png"
+cmake "$(SolutionDir)..\..\sdk\libjpeg-turbo" -B "$(SolutionDir)..\..\sdk\libjpeg-turbo\build\$(Platform)" -A $(Platform)
+cmake --build "$(SolutionDir)..\..\sdk\libjpeg-turbo\build\$(Platform)" --config $(Configuration)</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;MSTD_DEVICE;MSTD_DX9;LIB_JPEG;LIB_PNG;IMGUI_IMPL_WIN32_DISABLE_GAMEPAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;MSTD_DEVICE;MSTD_DX9;IMGUI_IMPL_WIN32_DISABLE_GAMEPAD;LIB_JPEG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
-      <AdditionalIncludeDirectories>$(SolutionDir)Windows;../../mstd-lib;../../mstd-lib/Windows;../../mstd-lib/DX9;../../sony-lib;../../sdk/zlib;../../sdk/libjpeg-turbo/src;../../sdk/libpng;../../sdk/imgui;../../sdk/imgui/backends;../../sdk/imgui/misc/cpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)Windows;../../mstd-lib;../../mstd-lib/Windows;../../mstd-lib/DX9;../../sony-lib;../../sdk/zlib;../../sdk/libjpeg-turbo/build/$(Platform);../../sdk/libjpeg-turbo/src;../../sdk/libpng;../../sdk/imgui;../../sdk/imgui/backends;../../sdk/imgui/misc/cpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
@@ -321,7 +272,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>
       </AdditionalDependencies>
-      <AdditionalLibraryDirectories>../../sdk/libjpeg-turbo/bin/Debug/x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../sdk/libjpeg-turbo/build/$(Platform)/$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <Manifest>
       <AdditionalManifestFiles>".\\Windows\\manifest.xml" %(AdditionalManifestFiles)</AdditionalManifestFiles>
@@ -332,7 +283,9 @@
       <ResourceOutputFileName />
     </ManifestResourceCompile>
     <PreBuildEvent>
-      <Command>copy /y ".//icons.png" "$(SolutionDir)Build\$(Configuration)\$(Platform)\icons.png"</Command>
+      <Command>copy /y ".//icons.png" "$(SolutionDir)Build\$(Configuration)\$(Platform)\icons.png"
+cmake "$(SolutionDir)..\..\sdk\libjpeg-turbo" -B "$(SolutionDir)..\..\sdk\libjpeg-turbo\build\$(Platform)" -A $(Platform)
+cmake --build "$(SolutionDir)..\..\sdk\libjpeg-turbo\build\$(Platform)" --config $(Configuration)</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -341,11 +294,11 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;MSTD_DEVICE;MSTD_DX9;LIB_JPEG;LIB_PNG;IMGUI_IMPL_WIN32_DISABLE_GAMEPAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;MSTD_DEVICE;MSTD_DX9;LIB_JPEG;IMGUI_IMPL_WIN32_DISABLE_GAMEPAD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
-      <AdditionalIncludeDirectories>$(SolutionDir)Windows;../../mstd-lib;../../mstd-lib/Windows;../../mstd-lib/DX9;../../sony-lib;../../sdk/zlib;../../sdk/libjpeg-turbo/src;../../sdk/libpng;../../sdk/imgui;../../sdk/imgui/backends;../../sdk/imgui/misc/cpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)Windows;../../mstd-lib;../../mstd-lib/Windows;../../mstd-lib/DX9;../../sony-lib;../../sdk/zlib;../../sdk/libjpeg-turbo/build/$(Platform);../../sdk/libjpeg-turbo/src;../../sdk/libpng;../../sdk/imgui;../../sdk/imgui/backends;../../sdk/imgui/misc/cpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
@@ -355,14 +308,16 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>
       </AdditionalDependencies>
-      <AdditionalLibraryDirectories>../../sdk/libjpeg-turbo/bin/Release/x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../sdk/libjpeg-turbo/build/$(Platform)/$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <Manifest>
       <AdditionalManifestFiles>".\\Windows\\manifest.xml" %(AdditionalManifestFiles)</AdditionalManifestFiles>
       <EnableDpiAwareness>true</EnableDpiAwareness>
     </Manifest>
     <PreBuildEvent>
-      <Command>copy /y ".//icons.png" "$(SolutionDir)Build\$(Configuration)\$(Platform)\icons.png"</Command>
+      <Command>copy /y ".//icons.png" "$(SolutionDir)Build\$(Configuration)\$(Platform)\icons.png"
+cmake "$(SolutionDir)..\..\sdk\libjpeg-turbo" -B "$(SolutionDir)..\..\sdk\libjpeg-turbo\build\$(Platform)" -A $(Platform)
+cmake --build "$(SolutionDir)..\..\sdk\libjpeg-turbo\build\$(Platform)" --config $(Configuration)</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/Visual Studio 2022/ps-image/ps-image.vcxproj.filters
+++ b/Visual Studio 2022/ps-image/ps-image.vcxproj.filters
@@ -26,9 +26,6 @@
     <Filter Include="SDK">
       <UniqueIdentifier>{274f27ef-6b56-4b4b-a673-32ee2b7d7ff5}</UniqueIdentifier>
     </Filter>
-    <Filter Include="SDK\zlib">
-      <UniqueIdentifier>{53b65cf9-f7b2-497f-adf5-a8b0d177d19b}</UniqueIdentifier>
-    </Filter>
     <Filter Include="SDK\imgui">
       <UniqueIdentifier>{9d8e390a-886c-4499-9385-92be596f0bbc}</UniqueIdentifier>
     </Filter>
@@ -37,9 +34,6 @@
     </Filter>
     <Filter Include="SDK\imgui\misc">
       <UniqueIdentifier>{9e56711b-89e0-4970-8bde-97b0615e7fe9}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="SDK\libpng">
-      <UniqueIdentifier>{1eac0912-e668-4367-943a-a5486bcd1e13}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -148,99 +142,6 @@
     <ClCompile Include="..\..\sony-lib\sony_texture.cpp">
       <Filter>Sony</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\sdk\libpng\pngwrite.c">
-      <Filter>SDK\libpng</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\sdk\libpng\pngwtran.c">
-      <Filter>SDK\libpng</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\sdk\libpng\pngwutil.c">
-      <Filter>SDK\libpng</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\sdk\libpng\png.c">
-      <Filter>SDK\libpng</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\sdk\libpng\pngerror.c">
-      <Filter>SDK\libpng</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\sdk\libpng\pngget.c">
-      <Filter>SDK\libpng</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\sdk\libpng\pngmem.c">
-      <Filter>SDK\libpng</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\sdk\libpng\pngpread.c">
-      <Filter>SDK\libpng</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\sdk\libpng\pngread.c">
-      <Filter>SDK\libpng</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\sdk\libpng\pngrio.c">
-      <Filter>SDK\libpng</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\sdk\libpng\pngrtran.c">
-      <Filter>SDK\libpng</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\sdk\libpng\pngset.c">
-      <Filter>SDK\libpng</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\sdk\libpng\pngtest.c">
-      <Filter>SDK\libpng</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\sdk\libpng\pngtrans.c">
-      <Filter>SDK\libpng</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\sdk\libpng\pngwio.c">
-      <Filter>SDK\libpng</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\sdk\libpng\pngrutil.c">
-      <Filter>SDK\libpng</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\sdk\zlib\adler32.c">
-      <Filter>SDK\zlib</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\sdk\zlib\compress.c">
-      <Filter>SDK\zlib</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\sdk\zlib\crc32.c">
-      <Filter>SDK\zlib</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\sdk\zlib\deflate.c">
-      <Filter>SDK\zlib</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\sdk\zlib\gzclose.c">
-      <Filter>SDK\zlib</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\sdk\zlib\gzlib.c">
-      <Filter>SDK\zlib</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\sdk\zlib\gzread.c">
-      <Filter>SDK\zlib</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\sdk\zlib\gzwrite.c">
-      <Filter>SDK\zlib</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\sdk\zlib\infback.c">
-      <Filter>SDK\zlib</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\sdk\zlib\inffast.c">
-      <Filter>SDK\zlib</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\sdk\zlib\inflate.c">
-      <Filter>SDK\zlib</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\sdk\zlib\inftrees.c">
-      <Filter>SDK\zlib</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\sdk\zlib\trees.c">
-      <Filter>SDK\zlib</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\sdk\zlib\uncompr.c">
-      <Filter>SDK\zlib</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\sdk\zlib\zutil.c">
-      <Filter>SDK\zlib</Filter>
-    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Windows\resource.h">
@@ -333,60 +234,6 @@
     <ClInclude Include="..\..\mstd-lib\std_text.h">
       <Filter>Standard</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\sdk\libpng\png.h">
-      <Filter>SDK\libpng</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\sdk\libpng\pngconf.h">
-      <Filter>SDK\libpng</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\sdk\libpng\pngdebug.h">
-      <Filter>SDK\libpng</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\sdk\libpng\pnginfo.h">
-      <Filter>SDK\libpng</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\sdk\libpng\pnglibconf.h">
-      <Filter>SDK\libpng</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\sdk\libpng\pngpriv.h">
-      <Filter>SDK\libpng</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\sdk\libpng\pngstruct.h">
-      <Filter>SDK\libpng</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\sdk\zlib\zutil.h">
-      <Filter>SDK\zlib</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\sdk\zlib\crc32.h">
-      <Filter>SDK\zlib</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\sdk\zlib\deflate.h">
-      <Filter>SDK\zlib</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\sdk\zlib\gzguts.h">
-      <Filter>SDK\zlib</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\sdk\zlib\inffast.h">
-      <Filter>SDK\zlib</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\sdk\zlib\inffixed.h">
-      <Filter>SDK\zlib</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\sdk\zlib\inflate.h">
-      <Filter>SDK\zlib</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\sdk\zlib\inftrees.h">
-      <Filter>SDK\zlib</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\sdk\zlib\trees.h">
-      <Filter>SDK\zlib</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\sdk\zlib\zconf.h">
-      <Filter>SDK\zlib</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\sdk\zlib\zlib.h">
-      <Filter>SDK\zlib</Filter>
-    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Image Include="Windows\icon.ico">
@@ -408,18 +255,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-    <None Include="..\..\sdk\zlib\README">
-      <Filter>SDK\zlib</Filter>
-    </None>
-    <None Include="..\..\sdk\zlib\LICENSE">
-      <Filter>SDK\zlib</Filter>
-    </None>
-    <None Include="..\..\sdk\libpng\LICENSE">
-      <Filter>SDK\libpng</Filter>
-    </None>
-    <None Include="..\..\sdk\libpng\README">
-      <Filter>SDK\libpng</Filter>
-    </None>
   </ItemGroup>
   <ItemGroup>
     <Text Include="..\..\sdk\imgui\LICENSE.txt">


### PR DESCRIPTION
Added libjpeg-turbo build to the ps-image project. Due to the absence of zlib, the LIB_PNG flag and all libpng and zlib dependencies have been temporarily removed from the project.